### PR TITLE
Bump scala version to support Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,9 @@
     <!-- test gitlab action -->
     <java.version>11</java.version>
     <scala.2.10.version>2.10.5</scala.2.10.version>
-    <scala.version>${scala.2.10.version}</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
-    <scala.2.11.version>2.11.8</scala.2.11.version>
+    <scala.version>${scala.2.11.version}</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+    <scala.2.11.version>2.11.12</scala.2.11.version>
     <scalatest.version>3.0.7</scalatest.version>
     <scalacheck.version>1.12.5</scalacheck.version>
 
@@ -1907,7 +1907,7 @@
     <profile>
       <id>scala-2.10</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
         <scala.version>${scala.2.10.version}</scala.version>
@@ -1917,6 +1917,9 @@
 
     <profile>
       <id>scala-2.11</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <scala.version>${scala.2.11.version}</scala.version>
         <scala.binary.version>2.11</scala.binary.version>


### PR DESCRIPTION
Bump scala version to use oldest one which supports Java 11. See https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

### What is this PR for?
A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://zeppelin.apache.org/contribution/contributions.html


### What type of PR is it?
Bug Fix
Improvement
Feature
Documentation
Hot Fix
Refactoring
*Please leave your type of PR only*

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/ZEPPELIN/
* Put link here, and add [ZEPPELIN-*Jira number*] in PR title, eg. [ZEPPELIN-533]

### How should this be tested?
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need to update?
* Is there breaking changes for older versions?
* Does this needs documentation?
